### PR TITLE
lib: prevent usage of unknown schema type

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -68,8 +68,9 @@ Schema.prototype._configure = function(definition) {
     throw new Error('Invalid type definition');
   }
 
+  // handle undefined/unkown types
   if (typeof TYPES.BY_NAME[definition.type] !== 'number') {
-    throw new Error('Unknown type \'' + definition.type + '\'');
+    definition.type = TYPES.BY_ID[TYPES.UNKNOWN];
   }
 
   this.id = definition.id;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -68,6 +68,10 @@ Schema.prototype._configure = function(definition) {
     throw new Error('Invalid type definition');
   }
 
+  if (typeof TYPES.BY_NAME[definition.type] !== 'number') {
+    throw new Error('Unknown type \'' + definition.type + '\'');
+  }
+
   this.id = definition.id;
   this.type = TYPES.BY_NAME[definition.type];
 

--- a/test/test-schema-errors-unknown-type.js
+++ b/test/test-schema-errors-unknown-type.js
@@ -21,7 +21,7 @@ suite('schema-errors-unknown-type', function() {
       properties: []
     });
     assert(err);
-    assert.strictEqual('Unknown type \'' + unknownType + '\'', err.message);
+    assert.strictEqual('Unknown type', err.message);
   });
 
 });

--- a/test/test-schema-errors-unknown-type.js
+++ b/test/test-schema-errors-unknown-type.js
@@ -1,0 +1,27 @@
+'use strict';
+/* global suite: false, setup: false, test: false,
+    teardown: false, suiteSetup: false, suiteTeardown: false */
+var assert = require('assert');
+var Registry = require('../');
+
+
+suite('schema-errors-unknown-type', function() {
+  var registry;
+
+  setup(function() {
+    registry = new Registry();
+  });
+
+
+  test('Unknow type', function() {
+    var unknownType = 'thisTypeIsVeryVeryUnknown';
+    var err = registry.addSchema({
+      id: 'xxx',
+      type: unknownType,
+      properties: []
+    });
+    assert(err);
+    assert.strictEqual('Unknown type \'' + unknownType + '\'', err.message);
+  });
+
+});


### PR DESCRIPTION
I don't think that actually using undefined types should behave like using undefined types :)
