### PR TITLE
schema: fix breakOnError option for array & mixed types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 Christopher Blasnik <christopher.blasnik+labs@magora.com>
 Clemens Solar <clemens.solar+labs@magora.com>
 Malte-Thorben Bruns <malte.bruns+labs@magora.com>
+Christian Steininger <christian.steininger+labs@magora.com>

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -326,6 +326,10 @@ Schema.prototype._validateMixed = function(value, context) {
   for (i = 0; i < this.enum.length; ++i) {
     this.enum[i]._validate(value, context, '*');
 
+    if (this._registry.breakOnError && context.errors.length > j) {
+      break;
+    }
+
     // no errors; matching schema found
     if (context.errors.length === j) {
       // remove all errors
@@ -421,6 +425,10 @@ Schema.prototype._validateArray = function(value, context) {
 
           for (j = 0; j < this.enum.length; ++j) {
             this.enum[j]._validate(value[i], context, i);
+          }
+
+          if (this._registry.breakOnError && context.errors.length > eTotal) {
+            break;
           }
 
           // less errors than tested schemas

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "changelog42": "0.9.0",
     "eslint": "2.11.1",
     "istanbul": "0.4.3",
-    "mocha": "2.4.5"
+    "mocha": "2.5.3"
   },
   "scripts": {
     "lint": "eslint ./",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "changelog42": "0.9.0",
-    "eslint": "2.5.3",
+    "eslint": "2.11.1",
     "istanbul": "0.4.2",
     "mocha": "2.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "changelog42": "0.9.0",
     "eslint": "2.11.1",
-    "istanbul": "0.4.2",
+    "istanbul": "0.4.3",
     "mocha": "2.4.5"
   },
   "scripts": {

--- a/test/break-on-error.test.js
+++ b/test/break-on-error.test.js
@@ -1,0 +1,39 @@
+'use strict';
+/* global suite: false, setup: false, test: false,
+    teardown: false, suiteSetup: false, suiteTeardown: false */
+var assert = require('assert');
+var Registry = require('../');
+
+
+suite('breakOnError', function() {
+  var registry;
+
+
+  setup(function() {
+    registry = new Registry({breakOnError: true});
+  });
+
+
+  test('mixed', function() {
+    registry.addSchema({
+      id: 'break-on-error:mixed',
+      type: 'mixed',
+      enum: [{type: 'string'}, {type: 'number'}]
+    });
+
+    var errors = registry.test('break-on-error:mixed', true);
+    assert.deepEqual(errors, [['*', 'string', 'type', true]]);
+  });
+
+
+  test('array', function() {
+    registry.addSchema({
+      id: 'break-on-error:array',
+      type: 'array',
+      enum: [{type: 'string'}, {type: 'number'}]
+    });
+
+    var errors = registry.test('break-on-error:array', [true, false, 1]);
+    assert.deepEqual(errors, [['0', 'string', 'type', true]]);
+  });
+});


### PR DESCRIPTION
With breakOnError enabled calls to schema._validate()
immediately return when there is already an error in
the current context.
The array & mixed type error detection, prior to this fix,
would have assumed that at least one schema is valid and
therefore remove all other errors for the current value.
